### PR TITLE
add traefik

### DIFF
--- a/platform-infrastructure-base/kustomization.yaml
+++ b/platform-infrastructure-base/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - sealedsecrets
   - iotedge
   - namespaces
+  - traefik

--- a/platform-infrastructure-base/traefik/kustomization.yaml
+++ b/platform-infrastructure-base/traefik/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: flux-system
+resources:
+  - release.yaml

--- a/platform-infrastructure-base/traefik/release.yaml
+++ b/platform-infrastructure-base/traefik/release.yaml
@@ -1,0 +1,38 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: traefik
+  namespace: kube-system
+spec:
+  releaseName: traefik
+  targetNamespace: kube-system
+  chart: 
+    spec: 
+      chart: traefik
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: flux-system
+      version: "9.11.0"
+  interval: 1h0m0s
+  install:
+    remediation:
+      retries: 3
+  values:
+    ports:
+      mqtt:
+        port: 1883
+        expose: true
+        exposedPort: 1883
+        protocol: TCP
+    logs:
+      general:
+        level: ERROR
+    access:
+      enabled: true
+    ingressRoute:
+      dashboard:
+        enabled: false
+    resources:
+      requests:
+        memory: 64Mi


### PR DESCRIPTION
Adds traefik ingress controller. I've defaulted to including the MQTT port as I think most installations are going to have it.
Any that don't require it can override in their repo by overriding with `expose: false` for that port.